### PR TITLE
fix: Strip Content-Length header from DELETE method too

### DIFF
--- a/signing_transport.go
+++ b/signing_transport.go
@@ -77,7 +77,7 @@ func (p *SigningRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 	}
 
-	if req.Method == "GET" || req.Method == "HEAD" {
+	if req.Method == "GET" || req.Method == "HEAD" || req.Method == "DELETE" {
 		delete(req.Header, "Content-Length")
 	}
 


### PR DESCRIPTION
This is necessary for operations such as deleting indices.